### PR TITLE
[BUGFIX] Fix handling of `InstalledPackagesTrait`

### DIFF
--- a/src/InstalledPackagesTrait.php
+++ b/src/InstalledPackagesTrait.php
@@ -37,7 +37,7 @@ trait InstalledPackagesTrait
     static public function getInstalledPackages(): array
     {
         if (self::propertyExists(DescriberInterface::INSTALLED_PACKAGES)) {
-            return self::$installedPackages;
+            return self::$resolvedPackages;
         }
 
         return [];
@@ -56,7 +56,7 @@ trait InstalledPackagesTrait
             );
         }
         if (!static::arePackagesResolved()) {
-            static::resolvePackages();
+            static::resolvePackages($propertyName);
         }
         return true;
     }
@@ -72,7 +72,7 @@ trait InstalledPackagesTrait
         if (!self::isPackageInstalled($name)) {
             return null;
         }
-        return new Package(self::$installedPackages[$name]);
+        return new Package(self::$resolvedPackages[$name]);
     }
 
     /**
@@ -84,7 +84,7 @@ trait InstalledPackagesTrait
     static public function isPackageInstalled(string $name): bool
     {
         self::propertyExists(DescriberInterface::INSTALLED_PACKAGES);
-        return (array_key_exists($name, self::$installedPackages));
+        return (array_key_exists($name, self::$resolvedPackages));
     }
 
     protected static function arePackagesResolved(): bool
@@ -92,11 +92,11 @@ trait InstalledPackagesTrait
         return is_array(static::$resolvedPackages);
     }
 
-    protected static function resolvePackages(): void
+    protected static function resolvePackages(string $propertyName): void
     {
-        if (!property_exists(static::class, DescriberInterface::INSTALLED_PACKAGES)) {
+        if (!property_exists(static::class, $propertyName)) {
             return;
         }
-        static::$resolvedPackages = unserialize(static::${DescriberInterface::INSTALLED_PACKAGES}) ?: [];
+        static::$resolvedPackages = unserialize(static::${$propertyName}) ?: [];
     }
 }


### PR DESCRIPTION
This PR is a follow-up to #1. It includes:

* Use of `$resolvedPackages` instead of serialized `$installedPackages`
* Fix of test cases for `InstalledPackagesTrait`

## Usage of correct property

With #1, `var_export()` was replaced by `serialize()`. Therefore the `BundleDescriber` class property `$installedPackages` does no longer contain an array, but rather its serialized representation. This leads to the fact that in case one uses the `InstalledPackagesTrait` to access this property, it needs to be resolved first (using `unserialize()` on first access – this was already handled with #1) and should then return the resolved values from `$resolvedPackages`.

With #1, this was only partially implemented and has now been streamlined. Since the `InstalledPackagesTraitTest` was currently not included in the test execution workflow, those problems have not been discovered.

## Fix of `InstalledPackagesTraitTest`

The Unit test class for `InstalledPackagesTrait` was currently not registered at the expected directory `tests/Unit`. This has now been streamlined and the tests have been adapted to the previous mentioned modifications in `InstalledPackagesTrait`.